### PR TITLE
Feat/m7s explosion：补充解法图

### DIFF
--- a/src/pages/07/m7s/explosion/solution_1.astro
+++ b/src/pages/07/m7s/explosion/solution_1.astro
@@ -17,7 +17,6 @@ import StratBoard from '@/components/StratBoard.astro'
   import { Role } from '@/pixi/role'
 
   import { getScale, YmToPx } from '@/pixi/utils'
-  import { setWaymark } from '@/pixi/waymark'
   import { $stratBoards } from '@/stores/stratBoards'
 
   import floor_img from '/assets/07/m7s/floor_p1_1@3x.png?url'
@@ -40,8 +39,6 @@ import StratBoard from '@/components/StratBoard.astro'
     floor.scale.set(getScale())
     container.addChild(floor)
 
-    // await setWaymark(container, waymarkData, 0.65)
-
     const squareMask = new Graphics()
     const width = 46.4 * YmToPx // 39.8 46.4
     squareMask.rect(-width / 2, -width / 2, width, width)
@@ -55,16 +52,7 @@ import StratBoard from '@/components/StratBoard.astro'
       { x: 13.86, y: 8 },
     ]
 
-    const imgList = [mark1_img, mark2_img, mark3_img]
-
-    for (let i = 0; i < omenParams.length; i++) {
-      const r = omenParams[i]
-      const texture = await Assets.load(imgList[i])
-      const sprite = new Sprite(texture)
-      sprite.anchor.set(0.5, 0.5)
-      sprite.position.set(r.x * YmToPx, r.y * YmToPx)
-      container.addChild(sprite)
-    }
+    
 
     // prox_img to replace
     // const endTexture = await Assets.load(end_img) 
@@ -130,49 +118,81 @@ import StratBoard from '@/components/StratBoard.astro'
       drawProxCircle(p, 3)
     })
 
-    const roleParams: { type: RoleType; tag: string; x: number; y: number; a: number }[] = [
-      { type: 'all', tag: '', x: 3, y: -16, a: 1 },
-    ]
+    // 标注陨石顺序
+    const imgList = [mark1_img, mark2_img, mark3_img]
+    for (let i = 0; i < omenParams.length; i++) {
+      const r = omenParams[i]
+      const texture = await Assets.load(imgList[i])
+      const sprite = new Sprite(texture)
+      sprite.anchor.set(0.5, 0.5)
+      sprite.position.set(r.x * YmToPx, r.y * YmToPx)
+      sprite.scale.set(getScale())
+      container.addChild(sprite)
+    }
 
+    // 职业图标
+    const roleParams: { type: RoleType; tag: string; x: number; y: number; a: number }[] = [
+      { type: 'all', tag: '', x: 14, y: 12, a: 1 },
+    ]
     roleParams.forEach((r) => {
       const role = new Role(r.type, r.tag)
       role.scale.set(0.4)
       role.position.set(r.x * YmToPx, r.y * YmToPx)
       role.alpha = r.a
+      role.scale.set(getScale(40))
       container.addChild(role)
     })
 
     function drawArrow(
       from: { x: number; y: number }, 
       to: { x: number; y: number }, 
-      color = 0xff66cc
+      color = 0xff66cc,
+      shrinkRatio = 0.92
     ) {
       const dx = to.x - from.x
       const dy = to.y - from.y
       const angle = Math.atan2(dy, dx)
-      const distance = Math.sqrt(dx * dx + dy * dy)
+
+      const length = Math.sqrt(dx * dx + dy * dy)
+      const shrinkDist = length * (1 - shrinkRatio)
+      const dirX = dx / length
+      const dirY = dy / length
+      const shortFrom = {
+        x: from.x + dirX * shrinkDist,
+        y: from.y + dirY * shrinkDist,
+      }
+      const shortTo = {
+        x: to.x - dirX * shrinkDist,
+        y: to.y - dirY * shrinkDist,
+      }
 
       const arrow = new Graphics()
       arrow.lineStyle(4, color)
-      arrow.moveTo(from.x * YmToPx, from.y * YmToPx)
-      arrow.lineTo(to.x * YmToPx, to.y * YmToPx)
+      arrow.moveTo(shortFrom.x * YmToPx, shortFrom.y * YmToPx)
+      arrow.lineTo(shortTo.x * YmToPx, shortTo.y * YmToPx)
 
       // 箭头头部三角形
       const arrowSize = 1.5
-      const endX = to.x * YmToPx
-      const endY = to.y * YmToPx
+      const endX = shortTo.x * YmToPx
+      const endY = shortTo.y * YmToPx
+
+      const leftX = endX - arrowSize * YmToPx * Math.cos(angle - Math.PI / 8)
+      const leftY = endY - arrowSize * YmToPx * Math.sin(angle - Math.PI / 8)
+      const rightX = endX - arrowSize * YmToPx * Math.cos(angle + Math.PI / 8)
+      const rightY = endY - arrowSize * YmToPx * Math.sin(angle + Math.PI / 8)
+
       arrow.beginFill(color)
       arrow.moveTo(endX, endY)
-      arrow.lineTo(endX - arrowSize * YmToPx * Math.cos(angle - Math.PI / 8), endY - arrowSize * YmToPx * Math.sin(angle - Math.PI / 8))
-      arrow.lineTo(endX - arrowSize * YmToPx * Math.cos(angle + Math.PI / 8), endY - arrowSize * YmToPx * Math.sin(angle + Math.PI / 8))
-      arrow.lineTo(endX, endY)
+      arrow.lineTo(leftX, leftY)
+      arrow.lineTo(rightX, rightY)
+      arrow.closePath()
       arrow.endFill()
 
       container.addChild(arrow)
     }
 
-    const from = omenParams[0]
-    const to = omenParams[2]
+    const from = omenParams[2]
+    const to = omenParams[0]
     drawArrow(from, to)
 
 

--- a/src/pages/07/m7s/explosion/solution_2.astro
+++ b/src/pages/07/m7s/explosion/solution_2.astro
@@ -24,7 +24,7 @@ import StratBoard from '@/components/StratBoard.astro'
   import mark2_img from '/assets/waymark/2@3x.png?url'
   import mark3_img from '/assets/waymark/3@3x.png?url'
 
-  const name = 'explosion_solution_step1'
+  const name = 'explosion_solution_step2'
 
   listenKeys($stratBoards, ['stratboard'], async (stratBoards) => {
     const app = stratBoards.stratboard
@@ -112,9 +112,8 @@ import StratBoard from '@/components/StratBoard.astro'
       container.addChild(g)
     }
 
-    omenParams.forEach(p => {
-      drawProxCircle(p, 3)
-    })
+    drawProxCircle(omenParams[1],3)
+    drawProxCircle(omenParams[2],3)
 
     // 标注陨石顺序
     const imgList = [mark1_img, mark2_img, mark3_img]
@@ -130,7 +129,7 @@ import StratBoard from '@/components/StratBoard.astro'
 
     // 职业图标
     const roleParams: { type: RoleType; tag: string; x: number; y: number; a: number }[] = [
-      { type: 'all', tag: '', x: 14, y: 12, a: 1 },
+      { type: 'all', tag: '', x: 12, y: -6, a: 1 },
     ]
     roleParams.forEach((r) => {
       const role = new Role(r.type, r.tag)

--- a/src/pages/07/m7s/explosion/solution_3.astro
+++ b/src/pages/07/m7s/explosion/solution_3.astro
@@ -24,7 +24,7 @@ import StratBoard from '@/components/StratBoard.astro'
   import mark2_img from '/assets/waymark/2@3x.png?url'
   import mark3_img from '/assets/waymark/3@3x.png?url'
 
-  const name = 'explosion_solution_step1'
+  const name = 'explosion_solution_step3'
 
   listenKeys($stratBoards, ['stratboard'], async (stratBoards) => {
     const app = stratBoards.stratboard
@@ -112,9 +112,7 @@ import StratBoard from '@/components/StratBoard.astro'
       container.addChild(g)
     }
 
-    omenParams.forEach(p => {
-      drawProxCircle(p, 3)
-    })
+    drawProxCircle(omenParams[2],3)
 
     // 标注陨石顺序
     const imgList = [mark1_img, mark2_img, mark3_img]
@@ -130,7 +128,7 @@ import StratBoard from '@/components/StratBoard.astro'
 
     // 职业图标
     const roleParams: { type: RoleType; tag: string; x: number; y: number; a: number }[] = [
-      { type: 'all', tag: '', x: 14, y: 12, a: 1 },
+      { type: 'all', tag: '', x: 1, y: -16, a: 1 },
     ]
     roleParams.forEach((r) => {
       const role = new Role(r.type, r.tag)


### PR DESCRIPTION
美术资源更新 #4 
- 修改solution_1，补充solution_2和solution_3，效果如下图；
- 陨石图标可以以后我再提issue单独优化

![explosion_solution_step1](https://github.com/user-attachments/assets/d105bd27-3363-4e3e-b27a-8c40287dbb2d)
![explosion_solution_step2](https://github.com/user-attachments/assets/dee613c9-1b46-445e-807f-d0d65d8591cf)
![explosion_solution_step3](https://github.com/user-attachments/assets/a14341f3-924d-42b2-8007-e3c72364b6d0)
