### PR TITLE
feat: 使用 Shader 实现 AOE 范围效果

### DIFF
--- a/src/filters/RangeAreaFilter.ts
+++ b/src/filters/RangeAreaFilter.ts
@@ -1,0 +1,59 @@
+import { Filter, GpuProgram } from 'pixi.js'
+
+import defaultVertexShader from '@/filters/shaders/default.wgsl?raw'
+import rangeAreaFragmentShader from '@/filters/shaders/rangeArea.wgsl?raw'
+
+const PRESETS = {
+  default: {
+    baseColor: [1, 0.635, 0.25, 0.3],
+    innerShadow1Color: [0.984, 0.82, 0.45, 1],
+    innerShadow1Size: 4.0,
+    innerShadow2Color: [1, 0.59, 0.207, 1],
+    innerShadow2Size: 16.0,
+  },
+  blue: {
+    baseColor: [0.5, 0.8, 1, 0.3],
+    innerShadow1Color: [0.184, 0.725, 1, 1],
+    innerShadow1Size: 4.0,
+    innerShadow2Color: [0.184, 0.725, 1, 1],
+    innerShadow2Size: 16.0,
+  },
+  purple: {
+    baseColor: [1, 0.482, 0.788, 0.3],
+    innerShadow1Color: [1, 0.5, 0.807, 1],
+    innerShadow1Size: 4.0,
+    innerShadow2Color: [1, 0.5, 0.807, 1],
+    innerShadow2Size: 16.0,
+  },
+}
+
+export interface RangeAreaFilterOptions {
+  preset?: keyof typeof PRESETS
+}
+
+export class RangeAreaFilter extends Filter {
+  constructor(options: RangeAreaFilterOptions) {
+    super({
+      gpuProgram: new GpuProgram({
+        vertex: {
+          source: defaultVertexShader,
+          entryPoint: 'main',
+        },
+        fragment: {
+          source: rangeAreaFragmentShader,
+          entryPoint: 'main',
+        },
+      }),
+      resources: {
+        uniforms: {
+          uInnerShadow1Color: { value: PRESETS[options.preset || 'default'].innerShadow1Color, type: 'vec4<f32>' },
+          uInnerShadow1Size: { value: PRESETS[options.preset || 'default'].innerShadow1Size, type: 'f32' },
+          uInnerShadow2Color: { value: PRESETS[options.preset || 'default'].innerShadow2Color, type: 'vec4<f32>' },
+          uInnerShadow2Size: { value: PRESETS[options.preset || 'default'].innerShadow2Size, type: 'f32' },
+          uBaseColor: { value: PRESETS[options.preset || 'default'].baseColor, type: 'vec4<f32>' },
+        },
+      },
+      padding: 200,
+    })
+  }
+}

--- a/src/filters/shaders/default.wgsl
+++ b/src/filters/shaders/default.wgsl
@@ -1,0 +1,50 @@
+struct GlobalFilterUniforms {
+  uInputSize:vec4<f32>,
+  uInputPixel:vec4<f32>,
+  uInputClamp:vec4<f32>,
+  uOutputFrame:vec4<f32>,
+  uGlobalFrame:vec4<f32>,
+  uOutputTexture:vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
+
+struct VSOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv : vec2<f32>
+};
+
+fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
+{
+    var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
+
+    position.x = position.x * (2.0 / gfu.uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*gfu.uOutputTexture.z / gfu.uOutputTexture.y) - gfu.uOutputTexture.z;
+
+    return vec4(position, 0.0, 1.0);
+}
+
+fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
+{
+    return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
+}
+
+fn globalTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
+{
+  return  (aPosition.xy / gfu.uGlobalFrame.zw) + (gfu.uGlobalFrame.xy / gfu.uGlobalFrame.zw);  
+}
+
+fn getSize() -> vec2<f32>
+{
+  return gfu.uGlobalFrame.zw;
+}
+  
+@vertex
+fn main(
+  @location(0) aPosition : vec2<f32>, 
+) -> VSOutput {
+  return VSOutput(
+   filterVertexPosition(aPosition),
+   filterTextureCoord(aPosition)
+  );
+}

--- a/src/filters/shaders/rangeArea.wgsl
+++ b/src/filters/shaders/rangeArea.wgsl
@@ -1,0 +1,98 @@
+struct GlobalFilterUniforms {
+  uInputSize: vec4<f32>,
+  uInputPixel: vec4<f32>,
+  uInputClamp: vec4<f32>,
+  uOutputFrame: vec4<f32>,
+  uGlobalFrame: vec4<f32>,
+  uOutputTexture: vec4<f32>,
+};
+
+struct Uniforms {
+  uInnerShadow1Color: vec4<f32>,
+  uInnerShadow1Size: f32,
+  uInnerShadow2Color: vec4<f32>,
+  uInnerShadow2Size: f32,
+  uBaseColor: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
+@group(0) @binding(1) var uSampler: texture_2d<f32>;
+@group(0) @binding(2) var uSamplerSampler: sampler;
+@group(1) @binding(0) var<uniform> uniforms: Uniforms;
+
+fn getAlpha(uv: vec2<f32>) -> f32 {
+    return textureSample(uSampler, uSamplerSampler, uv).a;
+}
+
+fn findDisToEdge(ouv: vec2<f32>, size: f32) -> f32 {
+    var minDist = 999999.0;
+    let texSize: vec2<u32> = textureDimensions(uSampler);
+    let pixelSize = 1.0 / vec2<f32>(texSize);
+    var uv = ouv;
+    var minUv = uv;
+    
+    var step = size;
+    while (step >= 1.0) {
+        const SAMPLE_COUNT = 32u;
+        var directions: array<vec2<f32>, SAMPLE_COUNT>;
+        
+        for (var i = 0u; i < SAMPLE_COUNT; i++) {
+            let angle = f32(i) * 2.0 * 3.14159265359 / f32(SAMPLE_COUNT);
+            directions[i] = vec2<f32>(cos(angle), sin(angle));
+        }
+        
+        for (var i = 0u; i < SAMPLE_COUNT; i++) {
+            let offset = directions[i] * step * pixelSize;
+            let sampleUV = uv + offset;
+            let alpha = getAlpha(sampleUV);
+            
+            if (alpha == 0.0) {
+                let dist = length((sampleUV - ouv)*vec2<f32>(texSize));
+                if (dist < minDist) {
+                    minDist = dist;
+                    minUv = sampleUV;
+                }
+            }
+        }
+        
+        step = step / 2;  // 每次迭代减半步长
+        uv = minUv;
+    }
+    
+    return minDist;
+}
+
+@fragment
+fn main(@builtin(position) position: vec4<f32>, @location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+    let tex = textureSample(uSampler, uSamplerSampler, uv);
+
+    var innerShadow1 = vec4<f32>(0.0);
+    let dist = findDisToEdge(uv, uniforms.uInnerShadow1Size);
+
+    if (tex.a > 0.0) {
+        let alpha = max(0, 1.0 - dist / uniforms.uInnerShadow1Size);
+        innerShadow1 = uniforms.uInnerShadow1Color * alpha;
+        innerShadow1.a = alpha;
+    }
+
+    var innerShadow2 = vec4<f32>(0.0);
+    let dist2 = findDisToEdge(uv, uniforms.uInnerShadow2Size);
+
+    if (tex.a > 0.0 && dist2 < uniforms.uInnerShadow2Size) {
+        let alpha = max(0, 1.0 - dist2 / uniforms.uInnerShadow2Size);
+        innerShadow2 = uniforms.uInnerShadow2Color * alpha;
+        innerShadow2.a = alpha;
+    }
+    
+    var finalColor = tex;
+    
+    if (tex.a > 0.0) {
+        finalColor = uniforms.uBaseColor * uniforms.uBaseColor.a;
+    }
+
+    finalColor = innerShadow2 + finalColor * (1.0 - innerShadow2.a);
+    finalColor = innerShadow1 + finalColor * (1.0 - innerShadow1.a);
+
+    
+    return finalColor;
+}

--- a/src/pages/filter_examples/RangeAreaFilterExample.astro
+++ b/src/pages/filter_examples/RangeAreaFilterExample.astro
@@ -1,0 +1,74 @@
+---
+import Layout from '@/layouts/Layout.astro'
+import StratBoard from '@/components/StratBoard.astro'
+---
+
+<Layout title="Range Area Filter Example">
+  <div class="flex h-screen w-screen items-center justify-center">
+    <StratBoard key="stratboard" />
+    <!-- selector for preset -->
+    <div class="absolute top-10 left-10">
+      <label for="preset-selector">Preset:</label>
+      <select id="preset-selector">
+        <option value="default">Default</option>
+        <option value="blue">Blue</option>
+        <option value="purple">Purple</option>
+      </select>
+    </div>
+  </div>
+</Layout>
+
+<script>
+  import { listenKeys } from 'nanostores'
+  import { Assets, Container, Graphics, Sprite } from 'pixi.js'
+
+  import { RangeAreaFilter } from '@/filters/RangeAreaFilter'
+  import { getScale } from '@/pixi/utils'
+  import { $stratBoards } from '@/stores/stratBoards'
+
+  import floor_img from '/assets/demo/circle_floor.png?url'
+
+  listenKeys($stratBoards, ['stratboard'], async (stratBoards) => {
+    const app = stratBoards.stratboard
+
+    const container = new Container()
+    container.position.set(app.screen.width / 2, app.screen.height / 2)
+
+    const background = new Sprite(await Assets.load(floor_img))
+    background.position.set(app.screen.width / 2, app.screen.height / 2)
+    background.anchor.set(0.5, 0.5)
+    app.stage.addChild(background)
+
+    // Create a ring and rect, filter will only use alpha channel, so color doesn't matter.
+    const ring = new Graphics()
+    ring.circle(300, 300, 300)
+    ring.stroke({
+      color: '#000000',
+      width: 300,
+    })
+    container.addChild(ring)
+
+    const rect = new Graphics()
+    rect.rect(-300, 0, 600, 300)
+    rect.fill({ color: '#000000' })
+    container.addChild(rect)
+
+    // Apply the RangeAreaFilter to the container
+    container.filters = [new RangeAreaFilter({ preset: 'default' })]
+
+    app.stage.scale.set(getScale())
+
+    app.stage.addChild(container)
+
+    app.ticker.add(() => {
+      ring.position.x = Math.sin(app.ticker.lastTime / 1000) * 100
+      ring.position.y = Math.cos(app.ticker.lastTime / 1000) * 100
+    })
+
+    const presetSelector = document.getElementById('preset-selector')
+    presetSelector?.addEventListener('change', (e: Event) => {
+      const target = e.target as HTMLSelectElement
+      container.filters = [new RangeAreaFilter({ preset: target.value as 'default' | 'blue' | 'purple' })]
+    })
+  })
+</script>


### PR DESCRIPTION
相关讨论见 #7 。

主要编写了Shader 生成两个内阴影的叠加，实现了类似 AOE 范围的效果；通过实现新的 RangeAreaFilter，使得 PixiJS 下能够很方便的使用这一效果，不受形状的限制：

```js
  // Apply the RangeAreaFilter to the container. 
  container.filters = [new RangeAreaFilter({ preset: 'default' })]
```

RangeAreaFilter 提供了三种颜色的预设（`default`, `blue`, `purple`)，对应游戏内三种不同颜色的 AOE 范围。

Filter 提供了一个样例页面用于展示效果，位于 `/filter_examples/RangeAreaFilterExample`。

![example](https://github.com/user-attachments/assets/43f4c6d3-d808-4131-b436-a5d2abe7429a)

## TODO

目前只实现了 WebGPU Shader，RangeAreaFilter 在某些浏览器下可能无法正常运行，还需提供 WebGL Shader 实现。

- [ ] WebGL Shader 实现
- [ ] 样式调整