### PR TITLE
feat: aoe anti-aliasing

### DIFF
--- a/src/pages/07/m7s/floor_p2_3_test.astro
+++ b/src/pages/07/m7s/floor_p2_3_test.astro
@@ -11,8 +11,9 @@ import StratBoard from '@/components/StratBoard.astro'
 
 <script>
   import { listenKeys } from 'nanostores'
-  import { Assets, BlurFilter, Container, Graphics, Sprite } from 'pixi.js'
+  import { Assets, Container, Graphics, Sprite } from 'pixi.js'
 
+  import { RangeAreaFilter } from '@/filters/RangeAreaFilter'
   import { getScale } from '@/pixi/utils'
   import { setWaymark } from '@/pixi/waymark'
   import { $stratBoards } from '@/stores/stratBoards'
@@ -38,42 +39,26 @@ import StratBoard from '@/components/StratBoard.astro'
 
     await setWaymark(container, waymarkDataDB, 0.65)
 
-    // 原始线条
-    const aoeLine = new Graphics()
-    aoeLine.circle(0, 0, 100)
-    aoeLine.stroke({ width: 1.5, color: 0xf9de71, alpha: 1 })
-    aoeLine.circle(0, 0, 40)
-    aoeLine.stroke({ width: 1.5, color: 0xf9de71, alpha: 1 })
+    const FACTOR = 2
 
-    // 线条模糊
-    const aoeLineBlur = new Graphics()
-    aoeLineBlur.circle(0, 0, 100)
-    aoeLineBlur.stroke({ width: 2, color: 0xff9f3d, alpha: 1 })
-    aoeLineBlur.circle(0, 0, 40)
-    aoeLineBlur.stroke({ width: 2, color: 0xff9f3d, alpha: 1 })
-    // 简单模糊
-    const blurFilter = new BlurFilter()
-    blurFilter.blur = 6
-    aoeLineBlur.filters = [blurFilter]
+    function createRing(innerRadius: number, outerRadius: number): Sprite {
+      const graphics = new Graphics()
+      graphics.circle(0, 0, outerRadius * FACTOR)
+      graphics.fill({ color: '0x000000' })
+      graphics.circle(0, 0, innerRadius * FACTOR)
+      graphics.cut()
 
-    // Zoom模糊
-    // const zoomFilter = new ZoomBlurFilter()
-    // zoomFilter.strength = 0.03
-    // zoomFilter.centerX = 20
-    // zoomFilter.centerY = 20
-    // zoomFilter.innerRadius = 0
-    // aoeLineBlur.filters = [zoomFilter]
+      graphics.filters = [new RangeAreaFilter({ preset: 'default' })]
 
-    // AOE底色
-    const aoe = new Graphics()
-    aoe.circle(0, 0, 100)
-    aoe.fill({ color: '0xff9f3d', alpha: 0.2 })
-    aoe.circle(0, 0, 40)
-    aoe.cut()
+      const texture = app.renderer.extract.texture(graphics)
+      const sprite = Sprite.from(texture)
+      sprite.anchor.set(0.5, 0.5)
+      sprite.scale.set(1 / FACTOR)
 
-    container.addChild(aoeLine)
-    container.addChild(aoeLineBlur)
-    container.addChild(aoe)
+      return sprite
+    }
+
+    container.addChild(createRing(40, 100))
 
     // const squareMask = new Graphics()
     // const width = 50.1 * YmToPx // 46.4

--- a/src/pixi/aoe_deep.ts
+++ b/src/pixi/aoe_deep.ts
@@ -6,6 +6,9 @@ import { Container, Graphics, Point, Rectangle, Sprite, Texture } from 'pixi.js'
 
 import { YmToPx } from './utils'
 
+const Factor = 2
+const ScaledYmToPx = YmToPx * Factor
+
 const COLORS = {
   aoe: '#e7a15d',
   innerShadow: '#FF751F',
@@ -33,7 +36,7 @@ export class AoETexture extends Texture {
 
   getCenterPivot() {
     if (this.type === 'ray' || this.type === 'fan') {
-      return new Point(YmToPx, this.height / 2)
+      return new Point(ScaledYmToPx, this.height / 2)
     } else {
       return new Point(this.width / 2, this.height / 2)
     }
@@ -70,10 +73,10 @@ export class AoE extends Container {
   private getComputedRectangle() {
     const bounds = this.getLocalBounds()
     const rect = new Rectangle(
-      bounds.x - YmToPx,
-      bounds.y - YmToPx,
-      bounds.width + YmToPx * 2,
-      bounds.height + YmToPx * 2,
+      bounds.x - ScaledYmToPx,
+      bounds.y - ScaledYmToPx,
+      bounds.width + ScaledYmToPx * 2,
+      bounds.height + ScaledYmToPx * 2,
     )
     return rect
   }
@@ -94,6 +97,7 @@ export class AoE extends Container {
     const sprite = Sprite.from(texture)
     const centerPivot = texture.getCenterPivot()
     sprite.pivot.set(centerPivot.x, centerPivot.y)
+    sprite.scale.set(1 / Factor)
     return sprite
   }
 
@@ -179,30 +183,30 @@ export class AoE extends Container {
 
   private static createRectGraphics(width: number, height: number, style?: FillInput) {
     const rect = new Graphics()
-    rect.rect((-width * YmToPx) / 2, (-height * YmToPx) / 2, width * YmToPx, height * YmToPx)
+    rect.rect((-width * ScaledYmToPx) / 2, (-height * ScaledYmToPx) / 2, width * ScaledYmToPx, height * ScaledYmToPx)
     rect.fill(style)
     return rect
   }
 
   private static createCircleGraphics(radius: number, style?: FillInput) {
     const circle = new Graphics()
-    circle.circle(0, 0, radius * YmToPx)
+    circle.circle(0, 0, radius * ScaledYmToPx)
     circle.fill(style)
     return circle
   }
 
   private static createRingGraphics(innerRadius: number, outerRadius: number, style?: FillInput) {
     const ring = new Graphics()
-    ring.circle(0, 0, outerRadius * YmToPx)
+    ring.circle(0, 0, outerRadius * ScaledYmToPx)
     ring.fill(style)
-    ring.circle(0, 0, innerRadius * YmToPx)
+    ring.circle(0, 0, innerRadius * ScaledYmToPx)
     ring.cut()
     return ring
   }
 
   private static createFanGraphics(radius: number, angle: number, style?: FillInput) {
     const fan = new Graphics()
-    fan.arc(0, 0, radius * YmToPx, (-angle * Math.PI) / 360, (angle * Math.PI) / 360)
+    fan.arc(0, 0, radius * ScaledYmToPx, (-angle * Math.PI) / 360, (angle * Math.PI) / 360)
     fan.lineTo(0, 0)
     fan.closePath()
     fan.fill(style)


### PR DESCRIPTION
使用更高分辨率渲染，再缩放回原大小以实现抗锯齿。

PR 提供了两处修改：

- `src/pages/07/m7s/floor_p2_3_test.astro`：单纯使用 RangeAreaFilter + 缩放抗锯齿的效果预览
- `src/pixi/aoe_deep.ts`：AoE 添加缩放抗锯齿的实现

TODO：Shadow 和 Glow 效果在高分辨率下会变得更小，如果需要精确还原的话，Filter 相关参数也应随 Factor 进行调整。

效果如下所示：

![dfb697988b31bd7a09d925d26cbb598a](https://github.com/user-attachments/assets/08fa4a89-784b-4694-9816-f193729eb450)

![a864fddd954ed8925a35a691e825a219](https://github.com/user-attachments/assets/b3402ae4-6e26-461f-804d-553ea720f483)
